### PR TITLE
added registration_enabled property for vnet links

### DIFF
--- a/environments/sandbox/service-core-compute-idam-sprod-internal.yml
+++ b/environments/sandbox/service-core-compute-idam-sprod-internal.yml
@@ -2,6 +2,7 @@ name: "service.core-compute-idam-sprod.internal"
 vnet_links:
   - link_name: "core-infra-vnet-idam-sprod-idam-internal"
     vnet_id: "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/core-infra-idam-sprod/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-idam-sprod"
+    registration_enabled: true
   - link_name: "mgmt-infra-sandbox-idam-internal"
     vnet_id: "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/mgmt-infra-sandbox/providers/Microsoft.Network/virtualNetworks/mgmt-infra-sandbox"
   - link_name: "core-infra-vnet-mgmt"

--- a/modules/azure-private-dns/dns_zone.tf
+++ b/modules/azure-private-dns/dns_zone.tf
@@ -12,5 +12,5 @@ resource "azurerm_private_dns_zone_virtual_network_link" "vnet_link" {
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.zone.name
   virtual_network_id    = each.value.vnet_id
-  registration_enabled = contains(keys(each.value), "registration_enabled") ? true : false
+  registration_enabled = contains(keys(each.value), "registration_enabled") ? each.value.registration_enabled : false
 }

--- a/modules/azure-private-dns/dns_zone.tf
+++ b/modules/azure-private-dns/dns_zone.tf
@@ -12,4 +12,5 @@ resource "azurerm_private_dns_zone_virtual_network_link" "vnet_link" {
   resource_group_name   = var.resource_group_name
   private_dns_zone_name = azurerm_private_dns_zone.zone.name
   virtual_network_id    = each.value.vnet_id
+  registration_enabled = contains(keys(each.value), "registration_enabled") ? true : false
 }

--- a/modules/azure-private-dns/variables.tf
+++ b/modules/azure-private-dns/variables.tf
@@ -13,11 +13,7 @@ variable "zone_name" {
 }
 
 variable "vnet_links" {
-  type = list(object({
-    link_name = string
-    vnet_id   = string
-  }))
-
+  type = list
   default = []
 }
 


### PR DESCRIPTION
### JIRA Link ###

https://tools.hmcts.net/jira/browse/SIDM-4096

### Change description ###

Added support for enabling auto vm registration on vnet link resources. The vnet_links variable type has been changed to a simple list as tf does not support optional properties on well-defined objects.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
