### PR TITLE
SIDM-3907 - idam-prod v2 tactical dns update 

### DIFF
--- a/environments/prod/prod-platform-hmcts-net.yml
+++ b/environments/prod/prod-platform-hmcts-net.yml
@@ -296,28 +296,16 @@ cname:
     record: idam-api-idam-ethosldata.service.core-compute-idam-ethosldata.internal.
     ttl: 300
   - name: idam-api
-    record: idam-api-idam-prod.service.core-compute-idam-prod.internal.
+    record: idam-api-prod.service.core-compute-prod.internal.
     ttl: 60
-  - name: idam-api-pregolive
-    record: idam-api-idam-prod.service.core-compute-idam-prod.internal.
-    ttl: 300
   - name: idam-web-admin
-    record: hmcts-idam-web-admin-idam-prod.trafficmanager.net.
-    ttl: 60
-  - name: idam-web-public
-    record: hmcts-idam-web-public-idam-prod.trafficmanager.net.
+    record: idam-web-admin-prod.service.core-compute-prod.internal.
     ttl: 60
   - name: tmidam-web-public
     record: 7436ed5c-c64c-4053-9c36-6d8ee8702a6d.cloudapp.net.
     ttl: 60
   - name: tmidam-web-admin
     record: 7436ed5c-c64c-4053-9c36-6d8ee8702a6d.cloudapp.net.
-    ttl: 60
-  - name: idam-api-prod2
-    record: idam-api-prod.service.core-compute-prod.internal.
-    ttl: 60
-  - name: idam-web-admin-prod2
-    record: idam-web-admin-prod.service.core-compute-prod.internal.
     ttl: 60
   - name: payment
     record: prod-waf-additional.platform.hmcts.net.


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SIDM-3907

### Change description ###

idam-prod dns update

replaces https://github.com/hmcts/dns-role/pull/307

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```