### PR TITLE
fix: incorrect sbox vnet resource id

### DIFF
--- a/environments/sandbox/service-core-compute-idam-sprod-internal.yml
+++ b/environments/sandbox/service-core-compute-idam-sprod-internal.yml
@@ -12,6 +12,6 @@ vnet_links:
   - link_name: "core-infra-vnet-sandbox-internal"
     vnet_id: "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/core-infra-sandbox/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-sandbox"
   - link_name: "core-sbox-vnet"
-    vnet_id: "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/core-infra-sandbox/providers/Microsoft.Network/virtualNetworks/core-sbox-vnet"
+    vnet_id: "/subscriptions/b72ab7b7-723f-4b18-b6f6-03b0f2c6a1bb/resourceGroups/aks-infra-sbox-rg/providers/Microsoft.Network/virtualNetworks/core-sbox-vnet"
 A: []
 cname: []


### PR DESCRIPTION
### Change description ###

Fixing the sandbox sprod vnet link as it had the incorrect resource id

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
