### PR TITLE
Remove unneeded demo DNS records

### DIFF
--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -10,90 +10,8 @@ vnet_links:
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/rg-mgmt/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-mgmt"
   - link_name: "reform-mgmt-core-vnet"
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/reformMgmtCoreRG/providers/Microsoft.Network/virtualNetworks/reformMgmtCoreVNet"
-A:
-  - name: www.featuretoggle
-    record:
-    - 51.140.41.143
-    ttl: 300
-  - name: gateway-ccd
-    record:
-    - 51.11.5.163
-    ttl: 300
-  - name: idam-api
-    record:
-    - 10.11.15.221
-    ttl: 300
-  - name: idam-web-admin
-    record:
-    - 51.11.5.163
-    ttl: 300
-  - name: idam-web-public
-    record:
-    - 51.11.5.163
-    ttl: 300
-  - name: paybubble
-    record:
-    - 51.11.25.221
-    ttl: 300
-  - name: cmc-demo-claim-store
-    record:
-      - 10.11.15.221
-    ttl: 300
+A: []
 cname:
-  - name: www.moneyclaims
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: www.moneyclaims-legal
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: www.ccd
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: gateway.ccd
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: return-case-doc.ccd
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: return-case-doc-ccd
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: fees-register
-    record: ccpay-demo-waf.demo.platform.hmcts.net.
-    ttl: 300
-  - name: www.fees-register
-    record: ccpay-demo-waf.demo.platform.hmcts.net.
-    ttl: 300
-  - name: fees-register-api
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: tmidam-web-public
-    record: 14fa5e11-1c38-4525-8f5e-cd7210606537.cloudapp.net.
-    ttl: 300
-  - name: tmidam-web-admin
-    record: 14fa5e11-1c38-4525-8f5e-cd7210606537.cloudapp.net.
-    ttl: 300
-  - name: payment
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: bar
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: www.bar
-    record: demo-waf.platform.hmcts.net.
-    ttl: 300
-  - name: probate
-    record: probate-appgw-demo.demo.platform.hmcts.net.
-    ttl: 300
-  - name: apply-for-probate
-    record: probate-appgw-demo.demo.platform.hmcts.net.
-    ttl: 300
-  - name: www.apply-for-probate
-    record: probate-appgw-demo.demo.platform.hmcts.net.
-    ttl: 300
-  - name: tmwww.apply-for-probate
-    record: probate-appgw-demo.demo.platform.hmcts.net.
-    ttl: 300
   - name: bulkscan
     record: f72fd46f-5e4b-42d9-9d23-697fb97f5640.cloudapp.net.
     ttl: 300
@@ -102,10 +20,4 @@ cname:
     ttl: 300
   - name: reformscan
     record: 2fbaac41-f785-421f-b3e0-d50484a7de2b.cloudapp.net.
-    ttl: 300
-  - name: awverify.sscs
-    record: awverify.sscs-tya-frontend-demo-shutter.azurewebsites
-    ttl: 300
-  - name: sscs
-    record: sscs-tya-frontend-demo-shutter.azurewebsites
     ttl: 300

--- a/environments/prod/prod-platform-hmcts-net.yml
+++ b/environments/prod/prod-platform-hmcts-net.yml
@@ -34,14 +34,6 @@ A:
     record:
     - 51.140.162.48
     ttl: 300
-  - name: demo-waf
-    record:
-    - 51.143.139.207
-    ttl: 300
-  - name: demo-waf-2
-    record:
-    - 51.141.226.211
-    ttl: 300
   - name: preview-waf
     record:
     - 51.143.139.66


### PR DESCRIPTION
These are now managed by external-dns and will be created automatically based off of ingress records