### PR TITLE
add private dns for idam-web-admin to frontdoor

### DIFF
--- a/environments/ithc/ithc-platform-hmcts-net.yml
+++ b/environments/ithc/ithc-platform-hmcts-net.yml
@@ -89,3 +89,6 @@ cname:
   - name: bar
     record: hmcts-ithc.azurefd.net.
     ttl: 300
+  - name: idam-web-admin
+    record: hmcts-ithc.azurefd.net.
+    ttl: 300

--- a/environments/sandbox/sandbox-platform-hmcts-net.yml
+++ b/environments/sandbox/sandbox-platform-hmcts-net.yml
@@ -68,3 +68,6 @@ cname:
   - name: bar
     record: sandbox-waf.sandbox.platform.hmcts.net.
     ttl: 300
+  - name: idam-web-admin
+    record: hmcts-sbox.azurefd.net.
+    ttl: 300


### PR DESCRIPTION
add private dns for idam-web-admin to frontdoor

vpn dns resolution does not query public.

