### PR TITLE
Move fees-register from CNAME to A record

### DIFF
--- a/environments/prod/prod-platform-hmcts-net.yml
+++ b/environments/prod/prod-platform-hmcts-net.yml
@@ -217,6 +217,14 @@ A:
     record:
     - 192.173.127.250
     ttl: 300
+  - name: fees-register
+    record:
+    - 10.13.32.122
+    ttl: 300
+  - name: www.fees-register
+    record:
+    - 10.13.32.122
+    ttl: 300
 cname:
   - name: sandbox-artifactory
     record: proxyin.reform.hmcts.net.
@@ -263,12 +271,6 @@ cname:
   - name: tmequality-and-diversity
     record: prod-waf-additional.platform.hmcts.net.
     ttl: 300    
-  - name: fees-register
-    record: hmcts-prod.azurefd.net.
-    ttl: 300
-  - name: www.fees-register
-    record: hmcts-prod.azurefd.net.
-    ttl: 300
   - name: tmwww.fees-register
     record: prod-waf-additional.platform.hmcts.net.
     ttl: 300


### PR DESCRIPTION
Point fees-register to AKS app gateway to allow VPN connected users to access the service via VPN and proxyout.  This is required as fees-register will be restricted by a a small set of MoJ public IP's.

**Before creating a pull request make sure that:**

- [ x ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
