### PR TITLE
Additional Privatelink Zones to support MI Data Platform Private Endpoints

### DIFF
--- a/components/privatelink/database-private-link.tf
+++ b/components/privatelink/database-private-link.tf
@@ -1,0 +1,13 @@
+data "local_file" "database-private-link" {
+  filename = "${path.cwd}/../../environments/privatelink/database-private-link.yml"
+}
+
+module "database-private-link" {
+  source              = "../../modules/azure-private-dns/"
+  cname_records       = yamldecode(data.local_file.database-private-link.content).cname
+  a_recordsets        = yamldecode(data.local_file.database-private-link.content).A
+  zone_name           = yamldecode(data.local_file.database-private-link.content).name
+  vnet_links          = yamldecode(data.local_file.database-private-link.content).vnet_links
+  resource_group_name = var.resource_group_name
+  env                 = var.env
+}

--- a/components/privatelink/datafactory-private-link.tf
+++ b/components/privatelink/datafactory-private-link.tf
@@ -1,0 +1,13 @@
+data "local_file" "datafactory-factory-private-link" {
+  filename = "${path.cwd}/../../environments/privatelink/datafactory-factory-private-link.yml"
+}
+
+module "datafactory-private-link" {
+  source              = "../../modules/azure-private-dns/"
+  cname_records       = yamldecode(data.local_file.datafactory-factory-private-link.content).cname
+  a_recordsets        = yamldecode(data.local_file.datafactory-factory-private-link.content).A
+  zone_name           = yamldecode(data.local_file.datafactory-factory-private-link.content).name
+  vnet_links          = yamldecode(data.local_file.datafactory-factory-private-link.content).vnet_links
+  resource_group_name = var.resource_group_name
+  env                 = var.env
+}

--- a/components/privatelink/vault-private-link.tf
+++ b/components/privatelink/vault-private-link.tf
@@ -1,0 +1,13 @@
+data "local_file" "vault-private-link" {
+  filename = "${path.cwd}/../../environments/privatelink/vault-private-link.yml"
+}
+
+module "vault-private-link" {
+  source              = "../../modules/azure-private-dns/"
+  cname_records       = yamldecode(data.local_file.vault-private-link.content).cname
+  a_recordsets        = yamldecode(data.local_file.vault-private-link.content).A
+  zone_name           = yamldecode(data.local_file.vault-private-link.content).name
+  vnet_links          = yamldecode(data.local_file.vault-private-link.content).vnet_links
+  resource_group_name = var.resource_group_name
+  env                 = var.env
+}

--- a/environments/privatelink/blob-private-link.yml
+++ b/environments/privatelink/blob-private-link.yml
@@ -9,22 +9,7 @@ vnet_links:
   - link_name: "reform-mgmt-core-vnet"
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/reformMgmtCoreRG/providers/Microsoft.Network/virtualNetworks/reformMgmtCoreVNet"
   - link_name: "bastion-prod-vnet"
-    vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"
-  # staging
-  - link_name: "ss-stg-vnet"
-    vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet"
-  # ithc
-  - link_name: "ss-ithc-vnet"
-    vnet_id: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet"
-  # test
-  - link_name: "ss-test-vnet"
-    vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet"
-  # dev
-  - link_name: "ss-dev-vnet"
-    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet"
-  # sandbox
-  - link_name: "ss-sbox-vnet"
-    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet"      
+    vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"  
 
 A: []
 cname: []

--- a/environments/privatelink/blob-private-link.yml
+++ b/environments/privatelink/blob-private-link.yml
@@ -9,7 +9,22 @@ vnet_links:
   - link_name: "reform-mgmt-core-vnet"
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/reformMgmtCoreRG/providers/Microsoft.Network/virtualNetworks/reformMgmtCoreVNet"
   - link_name: "bastion-prod-vnet"
-    vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"  
+    vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"
+  # staging
+  - link_name: "ss-stg-vnet"
+    vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet"
+  # ithc
+  - link_name: "ss-ithc-vnet"
+    vnet_id: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet"
+  # test
+  - link_name: "ss-test-vnet"
+    vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet"
+  # dev
+  - link_name: "ss-dev-vnet"
+    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet"
+  # sandbox
+  - link_name: "ss-sbox-vnet"
+    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet"      
 
 A: []
 cname: []

--- a/environments/privatelink/database-private-link.yml
+++ b/environments/privatelink/database-private-link.yml
@@ -1,4 +1,4 @@
-name: "privatelink.database.core.windows.net"
+name: "privatelink.database.windows.net"
 vnet_links:
   # staging
   - link_name: "ss-stg-vnet"

--- a/environments/privatelink/database-private-link.yml
+++ b/environments/privatelink/database-private-link.yml
@@ -1,0 +1,20 @@
+name: "privatelink.database.core.windows.net"
+vnet_links:
+  # staging
+  - link_name: "ss-stg-vnet"
+    vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet"
+  # ithc
+  - link_name: "ss-ithc-vnet"
+    vnet_id: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet"
+  # test
+  - link_name: "ss-test-vnet"
+    vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet"
+  # dev
+  - link_name: "ss-dev-vnet"
+    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet"
+  # sandbox
+  - link_name: "ss-sbox-vnet"
+    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet"
+
+A: []
+cname: []

--- a/environments/privatelink/database-private-link.yml
+++ b/environments/privatelink/database-private-link.yml
@@ -1,20 +1,5 @@
 name: "privatelink.database.windows.net"
-vnet_links:
-  # staging
-  - link_name: "ss-stg-vnet"
-    vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet"
-  # ithc
-  - link_name: "ss-ithc-vnet"
-    vnet_id: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet"
-  # test
-  - link_name: "ss-test-vnet"
-    vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet"
-  # dev
-  - link_name: "ss-dev-vnet"
-    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet"
-  # sandbox
-  - link_name: "ss-sbox-vnet"
-    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet"
+vnet_links: []
 
 A: []
 cname: []

--- a/environments/privatelink/datafactory-factory-private-link.yml
+++ b/environments/privatelink/datafactory-factory-private-link.yml
@@ -1,20 +1,5 @@
 name: "privatelink.datafactory.azure.net"
-vnet_links:
-  # staging
-  - link_name: "ss-stg-vnet"
-    vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet"
-  # ithc
-  - link_name: "ss-ithc-vnet"
-    vnet_id: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet"
-  # test
-  - link_name: "ss-test-vnet"
-    vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet"
-  # dev
-  - link_name: "ss-dev-vnet"
-    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet"
-  # sandbox
-  - link_name: "ss-sbox-vnet"
-    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet"
+vnet_links: []
 
 A: []
 cname: []

--- a/environments/privatelink/datafactory-factory-private-link.yml
+++ b/environments/privatelink/datafactory-factory-private-link.yml
@@ -1,0 +1,20 @@
+name: "privatelink.datafactory.azure.net"
+vnet_links:
+  # staging
+  - link_name: "ss-stg-vnet"
+    vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet"
+  # ithc
+  - link_name: "ss-ithc-vnet"
+    vnet_id: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet"
+  # test
+  - link_name: "ss-test-vnet"
+    vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet"
+  # dev
+  - link_name: "ss-dev-vnet"
+    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet"
+  # sandbox
+  - link_name: "ss-sbox-vnet"
+    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet"
+
+A: []
+cname: []

--- a/environments/privatelink/vault-private-link.yml
+++ b/environments/privatelink/vault-private-link.yml
@@ -1,20 +1,5 @@
 name: "privatelink.vaultcore.azure.net"
-vnet_links:
-  # staging
-  - link_name: "ss-stg-vnet"
-    vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet"
-  # ithc
-  - link_name: "ss-ithc-vnet"
-    vnet_id: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet"
-  # test
-  - link_name: "ss-test-vnet"
-    vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet"
-  # dev
-  - link_name: "ss-dev-vnet"
-    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet"
-  # sandbox
-  - link_name: "ss-sbox-vnet"
-    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet"
+vnet_links: []
 
 A: []
 cname: []

--- a/environments/privatelink/vault-private-link.yml
+++ b/environments/privatelink/vault-private-link.yml
@@ -1,0 +1,20 @@
+name: "privatelink.vaultcore.azure.net"
+vnet_links:
+  # staging
+  - link_name: "ss-stg-vnet"
+    vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/ss-stg-network-rg/providers/Microsoft.Network/virtualNetworks/ss-stg-vnet"
+  # ithc
+  - link_name: "ss-ithc-vnet"
+    vnet_id: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/ss-ithc-network-rg/providers/Microsoft.Network/virtualNetworks/ss-ithc-vnet"
+  # test
+  - link_name: "ss-test-vnet"
+    vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/ss-test-network-rg/providers/Microsoft.Network/virtualNetworks/ss-test-vnet"
+  # dev
+  - link_name: "ss-dev-vnet"
+    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/ss-dev-network-rg/providers/Microsoft.Network/virtualNetworks/ss-dev-vnet"
+  # sandbox
+  - link_name: "ss-sbox-vnet"
+    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/ss-sbox-network-rg/providers/Microsoft.Network/virtualNetworks/ss-sbox-vnet"
+
+A: []
+cname: []


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/confluence/display/RMDP/MI+Private+Endpoints+Testing
https://tools.hmcts.net/jira/browse/DTSPO-224

### Change description ###
DNS integration required to support private endpoints in use by MI Data Platform.

The following private dns zones are created:

- privatelink.database.windows.net
- privatelink.datafactory.azure.net
- privatelink.vaultcore.azure.net

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
