### PR TITLE
Privatelink zones in sandbox

### DIFF
--- a/components/sandbox/blob-private-link.tf
+++ b/components/sandbox/blob-private-link.tf
@@ -1,0 +1,13 @@
+data "local_file" "blob-private-link" {
+  filename = "${path.cwd}/../../environments/sandbox/blob-private-link.yml"
+}
+
+module "blob-private-link" {
+  source              = "../../modules/azure-private-dns/"
+  cname_records       = yamldecode(data.local_file.blob-private-link.content).cname
+  a_recordsets        = yamldecode(data.local_file.blob-private-link.content).A
+  zone_name           = yamldecode(data.local_file.blob-private-link.content).name
+  vnet_links          = yamldecode(data.local_file.blob-private-link.content).vnet_links
+  resource_group_name = var.resource_group_name
+  env                 = var.env
+}

--- a/components/sandbox/database-private-link.tf
+++ b/components/sandbox/database-private-link.tf
@@ -1,0 +1,13 @@
+data "local_file" "database-private-link" {
+  filename = "${path.cwd}/../../environments/sandbox/database-private-link.yml"
+}
+
+module "database-private-link" {
+  source              = "../../modules/azure-private-dns/"
+  cname_records       = yamldecode(data.local_file.database-private-link.content).cname
+  a_recordsets        = yamldecode(data.local_file.database-private-link.content).A
+  zone_name           = yamldecode(data.local_file.database-private-link.content).name
+  vnet_links          = yamldecode(data.local_file.database-private-link.content).vnet_links
+  resource_group_name = var.resource_group_name
+  env                 = var.env
+}

--- a/components/sandbox/datafactory-private-link.tf
+++ b/components/sandbox/datafactory-private-link.tf
@@ -1,0 +1,13 @@
+data "local_file" "datafactory-factory-private-link" {
+  filename = "${path.cwd}/../../environments/sandbox/datafactory-factory-private-link.yml"
+}
+
+module "datafactory-private-link" {
+  source              = "../../modules/azure-private-dns/"
+  cname_records       = yamldecode(data.local_file.datafactory-factory-private-link.content).cname
+  a_recordsets        = yamldecode(data.local_file.datafactory-factory-private-link.content).A
+  zone_name           = yamldecode(data.local_file.datafactory-factory-private-link.content).name
+  vnet_links          = yamldecode(data.local_file.datafactory-factory-private-link.content).vnet_links
+  resource_group_name = var.resource_group_name
+  env                 = var.env
+}

--- a/components/sandbox/postgres-private-link.tf
+++ b/components/sandbox/postgres-private-link.tf
@@ -1,0 +1,13 @@
+data "local_file" "postgres-private-link" {
+  filename = "${path.cwd}/../../environments/sandbox/postgres-private-link.yml"
+}
+
+module "postgres-private-link" {
+  source              = "../../modules/azure-private-dns/"
+  cname_records       = yamldecode(data.local_file.postgres-private-link.content).cname
+  a_recordsets        = yamldecode(data.local_file.postgres-private-link.content).A
+  zone_name           = yamldecode(data.local_file.postgres-private-link.content).name
+  vnet_links          = yamldecode(data.local_file.postgres-private-link.content).vnet_links
+  resource_group_name = var.resource_group_name
+  env                 = var.env
+}

--- a/components/sandbox/vault-private-link.tf
+++ b/components/sandbox/vault-private-link.tf
@@ -1,0 +1,13 @@
+data "local_file" "vault-private-link" {
+  filename = "${path.cwd}/../../environments/sandbox/vault-private-link.yml"
+}
+
+module "vault-private-link" {
+  source              = "../../modules/azure-private-dns/"
+  cname_records       = yamldecode(data.local_file.vault-private-link.content).cname
+  a_recordsets        = yamldecode(data.local_file.vault-private-link.content).A
+  zone_name           = yamldecode(data.local_file.vault-private-link.content).name
+  vnet_links          = yamldecode(data.local_file.vault-private-link.content).vnet_links
+  resource_group_name = var.resource_group_name
+  env                 = var.env
+}

--- a/environments/sandbox/blob-private-link.yml
+++ b/environments/sandbox/blob-private-link.yml
@@ -1,0 +1,5 @@
+name: "privatelink.blob.core.windows.net"
+vnet_links: []
+
+A: []
+cname: []

--- a/environments/sandbox/database-private-link.yml
+++ b/environments/sandbox/database-private-link.yml
@@ -1,0 +1,5 @@
+name: "privatelink.database.windows.net"
+vnet_links: []
+
+A: []
+cname: []

--- a/environments/sandbox/datafactory-factory-private-link.yml
+++ b/environments/sandbox/datafactory-factory-private-link.yml
@@ -1,0 +1,5 @@
+name: "privatelink.datafactory.azure.net"
+vnet_links: []
+
+A: []
+cname: []

--- a/environments/sandbox/postgres-private-link.yml
+++ b/environments/sandbox/postgres-private-link.yml
@@ -1,0 +1,5 @@
+name: "privatelink.postgres.database.azure.com"
+vnet_links: []
+
+A: []
+cname: []

--- a/environments/sandbox/vault-private-link.yml
+++ b/environments/sandbox/vault-private-link.yml
@@ -1,0 +1,5 @@
+name: "privatelink.vaultcore.azure.net"
+vnet_links: []
+
+A: []
+cname: []


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/confluence/display/RMDP/MI+Private+Endpoints+Testing
https://tools.hmcts.net/jira/browse/DTSPO-224


### Change description ###
Change to create privatelink zones in sandbox.  

VNet links for shared services vnets to the central privatelink DNS zones were previously created under [this PR](https://github.com/hmcts/aks-build-infrastructure/pull/7) but sandbox vnets link to the DTS-CFTSBOX-INTSVC subscription which is missing the privatelink DNS zones.

The below zone are created:

- privatelink.database.windows.net
- privatelink.blob.core.windows.net
- privatelink.vaultcore.azure.net
- privatelink.datafactory.azure.net
- privatelink.postgres.database.azure.com 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
