### PR TITLE
Remove docmosis old non-prod URLs

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -380,15 +380,6 @@ cname:
   - name: reformscan
     record: hmcts-prod.azurefd.net.
     ttl: 300
-  - name: docmosis-development
-    record: proxyin.reform.hmcts.net.
-    ttl: 300
-  - name: docmosis-testing
-    record: proxyin.reform.hmcts.net.
-    ttl: 300
-  - name: docmosis-ithc
-    record: proxyin.reform.hmcts.net.
-    ttl: 300
   - name: docmosis
     record: proxyin.reform.hmcts.net.
     ttl: 300


### PR DESCRIPTION
### Change description ###
Remove docmosis old non-prod URLs
docmosis-development.platform.hmcts.net 
docmosis-testing.platform.hmcts.net
docmosis-ithc.platform.hmcts.net 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
