### PR TITLE
docmosis dns change for Tuesday 23rd CR

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -219,6 +219,10 @@ A:
     record:
     - 192.173.127.250
     ttl: 300
+  - name: docmosis
+    record:
+    - 10.13.32.120
+    ttl: 300
   - name: camunda-bpm
     ttl: 300
     record:
@@ -391,9 +395,6 @@ cname:
     ttl: 300
   - name: reformscan
     record: hmcts-prod.azurefd.net.
-    ttl: 300
-  - name: docmosis
-    record: proxyin.reform.hmcts.net.
     ttl: 300
   - name: sslmon
     record: proxyin.reform.hmcts.net.


### PR DESCRIPTION
PR ready for CR window on Tuesday 23rd, pending approval

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-1567
CR - https://mojcppprod.service-now.com/nav_to.do?uri=%2Fchange_request.do%3Fsys_id%3Db8e961d41bcfa05089070e9c5e4bcb05%26sysparm_view%3D%26sysparm_domain%3Dnull%26sysparm_domain_scope%3Dnull

### Change description ###
Switching DNS to Docmosis hosted on AKS

