### PR TITLE
Revert "docmosis dns change for Tuesday 23rd CR"

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -219,10 +219,6 @@ A:
     record:
     - 192.173.127.250
     ttl: 300
-  - name: docmosis
-    record:
-    - 10.13.32.120
-    ttl: 300
   - name: camunda-bpm
     ttl: 300
     record:
@@ -395,6 +391,9 @@ cname:
     ttl: 300
   - name: reformscan
     record: hmcts-prod.azurefd.net.
+    ttl: 300
+  - name: docmosis
+    record: proxyin.reform.hmcts.net.
     ttl: 300
   - name: sslmon
     record: proxyin.reform.hmcts.net.


### PR DESCRIPTION
There were 2 templates from the SSCS team that were fixed in lower environments, but same errors are on prod now. These got stuck waiting for approval in sharepoint for production, they've tried again to get these approved this afternoon but haven't got it yet. So the team have asked for this to be reverted for now.

Reverts hmcts/azure-private-dns#212

