### PR TITLE
DTSPO-2801 - A records cleanup - service.core-compute-demo.internal

### DIFF
--- a/environments/demo/service-core-compute-demo-internal.yml
+++ b/environments/demo/service-core-compute-demo-internal.yml
@@ -14,13 +14,5 @@ vnet_links:
     vnet_id: "/subscriptions/b44eb479-9ae2-42e7-9c63-f3c599719b6f/resourceGroups/bastion-nonprod-rg/providers/Microsoft.Network/virtualNetworks/bastion-nonprod-vnet"
   - link_name: "pet-dev-vnet"
     vnet_id: "/subscriptions/58a2ce36-4e09-467b-8330-d164aa559c68/resourceGroups/pet_dev_network_resource_group/providers/Microsoft.Network/virtualNetworks/pet_dev_network"
-A:
-  - name: camunda-api-demo
-    record:
-      - 10.51.32.121
-    ttl: 300
-  - name: xui-terms-and-conditions-int-demo
-    record:
-      - 10.51.32.121
-    ttl: 300
+A: []
 cname: []


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2801


### Change description ###
Removed camunda-api-demo and xui-terms-and-conditions-int-demo  records as records now being managed in [Azure-Platform-Terraform pipeline](https://dev.azure.com/hmcts/CNP/_build/results?buildId=146536&view=logs&j=e09a6108-d8ca-571c-bcaa-f0c9df8f3bc1&t=9ed8b32b-16e0-596d-6ecc-d5d53d272cae).

**Note**: Both records already removed from state file as below.

Before removal:
![image](https://user-images.githubusercontent.com/22701260/120297810-62620600-c2c1-11eb-8c75-f25f449f1b98.png)

After removal:
![image](https://user-images.githubusercontent.com/22701260/120298042-9f2dfd00-c2c1-11eb-904d-2c1d631bfb19.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
