### PR TITLE
DTSPO-2801 - A records cleanup - service.core-compute-ithc.internal

### DIFF
--- a/environments/ithc/service-core-compute-ithc-internal.yml
+++ b/environments/ithc/service-core-compute-ithc-internal.yml
@@ -12,5 +12,9 @@ vnet_links:
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/reformMgmtCoreRG/providers/Microsoft.Network/virtualNetworks/reformMgmtCoreVNet"
   - link_name: "bastion-prod-vnet"
     vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"
-A: []
+A:
+  - name: ccd-data-0
+    record:
+    - 10.112.53.5
+    ttl: 300
 cname: []

--- a/environments/ithc/service-core-compute-ithc-internal.yml
+++ b/environments/ithc/service-core-compute-ithc-internal.yml
@@ -12,41 +12,5 @@ vnet_links:
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/reformMgmtCoreRG/providers/Microsoft.Network/virtualNetworks/reformMgmtCoreVNet"
   - link_name: "bastion-prod-vnet"
     vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"
-A:
-  - name: camunda-api-ithc
-    record:
-    - 10.10.40.121
-    ttl: 300
-  - name: ia-home-office-integration-api-ithc
-    record:
-    - 10.10.37.250
-    ttl: 300
-  - name: ia-home-office-mock-api-ithc
-    record:
-    - 10.10.37.250
-    ttl: 300
-  - name: finrem-emca-ithc
-    record:
-    - 10.10.37.250
-    ttl: 300
-  - name: finrem-ns-ithc
-    record:
-    - 10.10.37.250
-    ttl: 300
-  - name: finrem-ps-ithc
-    record:
-    - 10.10.37.250
-    ttl: 300
-  - name: finrem-cos-ithc
-    record:
-    - 10.10.37.250
-    ttl: 300
-  - name: finrem-dgcs-ithc
-    record:
-    - 10.10.37.250
-    ttl: 300
-  - name: ccd-data-0
-    record:
-    - 10.112.53.5
-    ttl: 300
+A: []
 cname: []


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2801


### Change description ###
Removed below ithc records from service.core-compute-ithc.internal zone as records now being managed in [Azure-Platform-Terraform pipeline](https://dev.azure.com/hmcts/CNP/_build/results?buildId=146536&view=logs&j=baff8f59-d787-56ea-fd00-6375512531c5&t=bf368e52-f3af-5457-f486-49f9c381ce75).

- camunda-api-ithc
- ia-home-office-integration-api-ithc
- ia-home-office-mock-api-ithc
- finrem-emca-ithc
- finrem-ns-ithc
- finrem-ps-ithc
- finrem-cos-ithc
- finrem-dgcs-ithc


**Note**: Records already removed from state file as below.

Before removal:
![image](https://user-images.githubusercontent.com/22701260/120315219-018ff900-c2d4-11eb-9118-109e6a9d312e.png)


After removal:
![image](https://user-images.githubusercontent.com/22701260/120315347-2b492000-c2d4-11eb-85a0-21bee6d9ea21.png)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
