### PR TITLE
DTSPO-2801 - A records cleanup - service.core-compute-test.internal

### DIFF
--- a/environments/test/service-core-compute-perftest-internal.yml
+++ b/environments/test/service-core-compute-perftest-internal.yml
@@ -14,33 +14,5 @@ vnet_links:
     vnet_id: "/subscriptions/b44eb479-9ae2-42e7-9c63-f3c599719b6f/resourceGroups/bastion-nonprod-rg/providers/Microsoft.Network/virtualNetworks/bastion-nonprod-vnet"
   - link_name: "pet-stg-vnet"
     vnet_id: "/subscriptions/58a2ce36-4e09-467b-8330-d164aa559c68/resourceGroups/pet_stg_network_resource_group/providers/Microsoft.Network/virtualNetworks/pet_stg_network"
-A:
-  - name: camunda-api-perftest
-    record:
-    - 10.61.32.121
-    ttl: 300
-  - name: div-cms-perftest
-    record:
-    - 10.61.32.121
-    ttl: 300
-  - name: finrem-emca-perftest
-    record:
-    - 10.61.32.121
-    ttl: 300
-  - name: finrem-ns-perftest
-    record:
-    - 10.61.32.121
-    ttl: 300
-  - name: finrem-ps-perftest
-    record:
-    - 10.61.32.121
-    ttl: 300
-  - name: finrem-cos-perftest
-    record:
-    - 10.61.32.121
-    ttl: 300
-  - name: idam-keycloak-perftest
-    record:
-    - 10.61.32.121
-    ttl: 300
+A: []
 cname: []


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2801


### Change description ###
Removed below ithc records from service.core-compute-test.internal zone as records now being managed in [Azure-Platform-Terraform](https://dev.azure.com/hmcts/CNP/_build/results?buildId=146536&view=logs&j=29698b4c-009f-51b4-e908-eae84317b3e4&t=adb3c60a-2cbe-5abb-6c95-d7583d6bd359) pipeline.

camunda-api-perftest
div-cms-perftest
finrem-emca-perftest
finrem-ns-perftest
finrem-ps-perftest
finrem-cos-perftest
idam-keycloak-perftest

**Note:** Records already removed from state file as below.

Before removal:
![image](https://user-images.githubusercontent.com/22701260/120359456-9825df80-c2ff-11eb-8295-ae17d1a704c7.png)


After removal:
![image](https://user-images.githubusercontent.com/22701260/120359741-f2bf3b80-c2ff-11eb-85cd-88e5400932a3.png)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
