### PR TITLE
DTSPO-2801 - A records cleanup - service.core-compute-aat.internal

### DIFF
--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -20,21 +20,5 @@ vnet_links:
     vnet_id: "/subscriptions/b44eb479-9ae2-42e7-9c63-f3c599719b6f/resourceGroups/bastion-nonprod-rg/providers/Microsoft.Network/virtualNetworks/bastion-nonprod-vnet"
   - link_name: "bastion-prod-vnet"
     vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"
-A:
-  - name: camunda-api-aat
-    record:
-    - 10.10.24.121
-    ttl: 300
-  - name: civil-damages-service-camunda-staging-aat
-    record:
-    - 10.10.24.121
-    ttl: 300
-  - name: civil-damages-ccd-camunda-staging-aat
-    record:
-    - 10.10.24.121
-    ttl: 300
-  - name: civil-damages-camunda-camunda-staging-aat
-    record:
-    - 10.10.24.121
-    ttl: 300
+A: []
 cname: []


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2801


### Change description ###
Removed below aat records from service.core-compute-aat.internal zone as records now being managed in [Azure-Platform-Terraform](https://dev.azure.com/hmcts/CNP/_build/results?buildId=146536&view=logs&j=be5b8c63-3921-5689-f864-94b62473cdb4&t=947ff93d-eb90-53ef-c524-d83cd6e1c5e3) pipeline.

camunda-api-aat
civil-damages-service-camunda-staging-aat
civil-damages-ccd-camunda-staging-aat
civil-damages-camunda-camunda-staging-aat

**Note**: Records already removed from state file as below.

Before removal:
![image](https://user-images.githubusercontent.com/22701260/120450590-7b81ba00-c388-11eb-9a7c-e0fb46deb7d6.png)


After removal:
![image](https://user-images.githubusercontent.com/22701260/120450687-994f1f00-c388-11eb-8035-e1959e0216df.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
