### PR TITLE
DTSPO-2801 - A record cleanup - service.core-compute-prod.internal

### DIFF
--- a/environments/prod/service-core-compute-prod-internal.yml
+++ b/environments/prod/service-core-compute-prod-internal.yml
@@ -16,9 +16,5 @@ vnet_links:
     vnet_id: "/subscriptions/58a2ce36-4e09-467b-8330-d164aa559c68/resourceGroups/pet_prod_network_resource_group/providers/Microsoft.Network/virtualNetworks/pet_prod_network"
   - link_name: "bastion-prod-vnet"
     vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"
-A:
-  - name: camunda-api-prod
-    record:
-    - 10.13.32.120
-    ttl: 300
+A: []
 cname: []


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2801


### Change description ###
Removed camunda-api-prod record from service.core-compute-prod.internal zone as records now being managed in [Azure-Platform-Terraform](https://dev.azure.com/hmcts/CNP/_build/results?buildId=146536&view=logs&j=5f9d94b3-2fc8-5ed6-3d29-dc1b692fe19b&t=6d9d5ab9-3732-5ac7-21ce-ea0b27c0fd31) pipeline.

Note: Record already removed from state file as below.

Before removal:
![image](https://user-images.githubusercontent.com/22701260/120470294-459a0100-c39b-11eb-9917-0de770b528bb.png)


After removal:
![image](https://user-images.githubusercontent.com/22701260/120470466-7417dc00-c39b-11eb-8366-aa4b9921b9b5.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
