### PR TITLE
update ITHC to use correct Load balancer IPs

### DIFF
--- a/environments/ithc/ithc-platform-hmcts-net.yml
+++ b/environments/ithc/ithc-platform-hmcts-net.yml
@@ -19,19 +19,19 @@ A:
     ttl: 300
   - name: prometheus-00
     record:
-    - 10.10.35.250
+    - 10.11.207.250
     ttl: 300
   - name: prometheus-01
     record:
-    - 10.10.39.250
+    - 10.11.223.250
     ttl: 300
   - name: alertmanager-00
     record:
-    - 10.10.35.250
+    - 10.11.207.250
     ttl: 300
   - name: alertmanager-01
     record:
-    - 10.10.39.250
+    - 10.11.223.250
     ttl: 300
   - name: camunda-bpm
     record:


### PR DESCRIPTION
### JIRA link (if applicable) ###

n/a

### Change description ###

Updated LB ip's for Prometheus as this is currently set for the old clusters.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
