### PR TITLE
Add VPN ext to private DNS

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -279,6 +279,10 @@ A:
     record:
     - 51.141.230.130
     ttl: 300
+  - name: vpn-ext
+    record:
+    - 51.141.230.130
+    ttl: 300
   - name: traefik-sds-00
     record:
     - 10.144.15.250


### PR DESCRIPTION
SSH isn't configured to work on the private IP

My suppliers endpoint scanner bypasses .platform.hmcts.net DNS entries for scanning but because this is just an IP address I can't hit it -.-

This should be okay, may need to add to public DNS but we'll see