### PR TITLE
Rename postgres private zone

### DIFF
--- a/environments/privatelink/postgres.yml
+++ b/environments/privatelink/postgres.yml
@@ -1,4 +1,4 @@
-name: "postgres.database.azure.com"
+name: "private.postgres.database.azure.com"
 vnet_links:
   - link_name: "reform-mgmt-core-vnet"
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/reformMgmtCoreRG/providers/Microsoft.Network/virtualNetworks/reformMgmtCoreVNet"


### PR DESCRIPTION
I'm worried that having it in the same zone name as the public one will cause issues.

I think this is safer