### PR TITLE
DTSPO-9705: Adding corresponding prod private dns entry

### DIFF
--- a/environments/prod/mailrelay-platform-hmcts-net.yml
+++ b/environments/prod/mailrelay-platform-hmcts-net.yml
@@ -35,3 +35,6 @@ cname:
   - name: "dev-in"
     ttl: 60
     record: "ss-dev-mailrelay.trafficmanager.net"
+  - name: "prod-in"
+    ttl: 60
+    record: "ss-prod-mailrelay.trafficmanager.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-9705


### Change description ###
Adding a corresponding private dns entry for mailrelay prod


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
