### PR TITLE
add cft-aat-vnet to staging-platform-hmcts-net.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ resources:
     endpoint: 'hmcts'
 
 variables:
-  agentPool: 'ubuntu-20.04'
+  agentPool: 'ubuntu-latest'
   product: 'cft-platform'
 
 stages:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ resources:
     endpoint: 'hmcts'
 
 variables:
-  agentPool: 'ubuntu-18.04'
+  agentPool: 'ubuntu-20.04'
   product: 'cft-platform'
 
 stages:

--- a/environments/staging/staging-platform-hmcts-net.yml
+++ b/environments/staging/staging-platform-hmcts-net.yml
@@ -8,6 +8,8 @@ vnet_links:
     vnet_id: "/subscriptions/b44eb479-9ae2-42e7-9c63-f3c599719b6f/resourceGroups/bastion-nonprod-rg/providers/Microsoft.Network/virtualNetworks/bastion-nonprod-vnet"
   - link_name: "cft-perftest-vnet"
     vnet_id: "/subscriptions/8a07fdcd-6abd-48b3-ad88-ff737a4b9e3c/resourceGroups/cft-perftest-network-rg/providers/Microsoft.Network/virtualNetworks/cft-perftest-vnet"
+  - link_name: "cft-aat-vnet"
+    vnet_id: "/subscriptions/96c274ce-846d-4e48-89a7-d528432298a7/resourceGroups/cft-aat-network-rg/providers/Microsoft.Network/virtualNetworks/cft-aat-vnet"
 A:
   - name: traefik-sds-00
     ttl: 300


### PR DESCRIPTION
### Change description ###
add cft-aat-vnet to staging-platform-hmcts-net.yml
 - cft-aat-vnet needs to connect to hmi-apim.staging.*

Updated build agent to fix deprecation error
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
