### PR TITLE
Add civil GA app records to point to traefik

### DIFF
--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -1,3 +1,4 @@
+current_aat_cluster: 10.10.159.250
 name: "service.core-compute-aat.internal"
 vnet_links:
   - link_name: "core-infra-vnet-preview-internal"
@@ -27,46 +28,46 @@ A:
     ttl: 300
   - name: neuvector01
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-camunda-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-ccd-camunda-staging-aat
     record:
-    - 10.10.159.250
+    - 
     ttl: 300
   - name: civil-ga-ccd-civil-service-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-ccd-data-store-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-ccd-definition-store-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-ccd-xui-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-civil-service-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-data-store-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-definition-store-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-xui-staging-aat
     record:
-    - 10.10.159.250
+    - ${current_aat_cluster}
     ttl: 300
 cname: []

--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -35,42 +35,32 @@ A:
     ttl: 300
 cname:
   - name: civil-ga-camunda-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-camunda-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-civil-service-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-data-store-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-definition-store-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-xui-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-civil-service-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-data-store-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-definition-store-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-xui-staging-aat
-    record:
-    - jenkins-cluster.service.core-compute-aat.internal.
+    record: jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300

--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -28,7 +28,7 @@ A:
     ttl: 300
   - name: neuvector01
     record:
-    - ${current_aat_cluster}
+    - 10.10.159.250
     ttl: 300
   - name: civil-ga-camunda-staging-aat
     record:

--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -36,7 +36,7 @@ A:
     ttl: 300
   - name: civil-ga-ccd-camunda-staging-aat
     record:
-    - 
+    - ${current_aat_cluster}
     ttl: 300
   - name: civil-ga-ccd-civil-service-staging-aat
     record:

--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -1,4 +1,3 @@
-jenkins_deployment_cluster: 10.10.159.250
 name: "service.core-compute-aat.internal"
 vnet_links:
   - link_name: "core-infra-vnet-preview-internal"
@@ -26,48 +25,52 @@ A:
     record:
     - 10.10.143.250
     ttl: 300
-  - name: neuvector01
+  - name: neuvector01 
     record:
     - 10.10.159.250
     ttl: 300
+  - name: jenkins-cluster
+    record:
+    - 10.10.159.250
+    ttl: 300
+cname: []
   - name: civil-ga-camunda-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-camunda-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-civil-service-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-data-store-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-definition-store-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-ccd-xui-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-civil-service-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-data-store-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-definition-store-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
   - name: civil-ga-xui-staging-aat
     record:
-    - ${jenkins_deployment_cluster}
+    - jenkins-cluster.service.core-compute-aat.internal.
     ttl: 300
-cname: []

--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -1,4 +1,4 @@
-current_aat_cluster: 10.10.159.250
+jenkins_deployment_cluster: 10.10.159.250
 name: "service.core-compute-aat.internal"
 vnet_links:
   - link_name: "core-infra-vnet-preview-internal"
@@ -32,42 +32,42 @@ A:
     ttl: 300
   - name: civil-ga-camunda-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-ccd-camunda-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-ccd-civil-service-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-ccd-data-store-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-ccd-definition-store-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-ccd-xui-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-civil-service-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-data-store-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-definition-store-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
   - name: civil-ga-xui-staging-aat
     record:
-    - ${current_aat_cluster}
+    - ${jenkins_deployment_cluster}
     ttl: 300
 cname: []

--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -29,4 +29,44 @@ A:
     record:
     - 10.10.159.250
     ttl: 300
+  - name: civil-ga-camunda-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-ccd-camunda-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-ccd-civil-service-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-ccd-data-store-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-ccd-definition-store-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-ccd-xui-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-civil-service-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-data-store-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-definition-store-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
+  - name: civil-ga-xui-staging-aat
+    record:
+    - 10.10.159.250
+    ttl: 300
 cname: []

--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -33,7 +33,7 @@ A:
     record:
     - 10.10.159.250
     ttl: 300
-cname: []
+cname:
   - name: civil-ga-camunda-staging-aat
     record:
     - jenkins-cluster.service.core-compute-aat.internal.


### PR DESCRIPTION
https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_a_to_c%2Fcivil-general-applications/detail/master/141/pipeline/389/ build failing as currently URLs point to appgw which terminates ssl, and can't access the sites in https as needed.


### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
