### PR TITLE
SIDM-8214 - Updated private DNS records for hmcts-access to match ingressHost

### DIFF
--- a/environments/ithc/ithc-platform-hmcts-net.yml
+++ b/environments/ithc/ithc-platform-hmcts-net.yml
@@ -94,7 +94,7 @@ cname:
   - name: idam-testing-support-api
     record: idam-testing-support-api-ithc.service.core-compute-ithc.internal.
     ttl: 300
-  - name: idam-hmcts-access
+  - name: hmcts-access
     record: hmcts-ithc.azurefd.net.
     ttl: 300
   - name: petitioner-frontend-aks

--- a/environments/sandbox/sandbox-platform-hmcts-net.yml
+++ b/environments/sandbox/sandbox-platform-hmcts-net.yml
@@ -174,7 +174,7 @@ cname:
   - name: idam-user-dashboard
     record: hmcts-sbox.azurefd.net.
     ttl: 300
-  - name: idam-hmcts-access
+  - name: hmcts-access
     record: hmcts-sbox.azurefd.net.
     ttl: 300
   - name: hmi-apim

--- a/environments/staging/aat-platform-hmcts-net.yml
+++ b/environments/staging/aat-platform-hmcts-net.yml
@@ -126,7 +126,7 @@ cname:
   - name: idam-user-dashboard
     record: hmcts-aat.azurefd.net.
     ttl: 300
-  - name: idam-hmcts-access
+  - name: hmcts-access
     record: hmcts-aat.azurefd.net.
     ttl: 300
   - name: payment

--- a/environments/test/perftest-platform-hmcts-net.yml
+++ b/environments/test/perftest-platform-hmcts-net.yml
@@ -117,7 +117,7 @@ cname:
   - name: idam-testing-support-api
     record: idam-testing-support-api-perftest.service.core-compute-perftest.internal.
     ttl: 300
-  - name: idam-hmcts-access
+  - name: hmcts-access
     record: hmcts-perftest.azurefd.net.
     ttl: 300
   - name: bulkscan


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/SIDM-8214

### Change description ###

- Updated CNAME on records from `idam-hmcts-access` to `hmcts-access`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
