### PR TITLE
Add docmosis private record to appgw

### DIFF
--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -53,6 +53,10 @@ A:
     record:
     - 10.254.0.232
     ttl: 300
+  - name: docmosis
+    record:
+    - 10.50.97.118
+    ttl: 300
 cname:
   - name: bulk-scanning
     record: 3644b292-ae3f-4055-ba68-4a9500e43659.cloudapp.net.

--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -21,10 +21,6 @@ A:
     record:
       - 10.145.15.250
     ttl: 300
-  - name: toffee-recipe-backend
-    record:
-      - 10.51.79.250
-    ttl: 300
   - name: cft-api-mgmt
     record:
     - 10.50.97.133


### PR DESCRIPTION
Tested with manual change, and flux change has been added so docmosis is fully moved to active/active. 

This change:
- Makes the DNS change permanent and points docmosis to appgw in demo


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
