### PR TITLE
CFT ITHC - C Name internal DNS entries to new cluster LB record, change Neuvector domain

### DIFF
--- a/environments/ithc/ithc-platform-hmcts-net.yml
+++ b/environments/ithc/ithc-platform-hmcts-net.yml
@@ -19,22 +19,6 @@ A:
     record:
     - 10.11.225.111
     ttl: 300
-  - name: prometheus-00
-    record:
-    - 10.11.207.250
-    ttl: 300
-  - name: prometheus-01
-    record:
-    - 10.11.223.250
-    ttl: 300
-  - name: alertmanager-00
-    record:
-    - 10.11.207.250
-    ttl: 300
-  - name: alertmanager-01
-    record:
-    - 10.11.223.250
-    ttl: 300
   - name: camunda-bpm
     record:
     - 10.11.225.111
@@ -66,6 +50,14 @@ A:
   - name: vh-wowza
     record:
     - 10.100.197.219
+    ttl: 300
+  - name: traefik-cft-00
+    record:
+    - 10.11.207.250
+    ttl: 300
+  - name: traefik-cft-01
+    record:
+    - 10.11.223.250
     ttl: 300
 cname:
   - name: c100-application
@@ -193,4 +185,28 @@ cname:
     ttl: 300
   - name: signalr
     record: vh-infra-core-ithc.service.signalr.net
+    ttl: 300
+  - name: prometheus-00
+    record: traefik-cft-00.ithc.platform.hmcts.net.
+    ttl: 300
+  - name: prometheus-01
+    record: traefik-cft-01.ithc.platform.hmcts.net.
+    ttl: 300
+  - name: alertmanager-00x
+    record: traefik-cft-00.ithc.platform.hmcts.net.
+    ttl: 300
+  - name: alertmanager-01
+    record: traefik-cft-01.ithc.platform.hmcts.net.
+    ttl: 300
+  - name: cft-neuvector00
+    record: traefik-cft-00.ithc.platform.hmcts.net.
+    ttl: 300
+  - name: cft-neuvector00-api
+    record: traefik-cft-00.ithc.platform.hmcts.net.
+    ttl: 300
+  - name: cft-neuvector01
+    record: traefik-cft-01.ithc.platform.hmcts.net.
+    ttl: 300
+  - name: cft-neuvector01-api
+    record: traefik-cft-01.ithc.platform.hmcts.net.
     ttl: 300

--- a/environments/ithc/ithc-platform-hmcts-net.yml
+++ b/environments/ithc/ithc-platform-hmcts-net.yml
@@ -192,7 +192,7 @@ cname:
   - name: prometheus-01
     record: traefik-cft-01.ithc.platform.hmcts.net.
     ttl: 300
-  - name: alertmanager-00x
+  - name: alertmanager-00
     record: traefik-cft-00.ithc.platform.hmcts.net.
     ttl: 300
   - name: alertmanager-01

--- a/environments/ithc/service-core-compute-ithc-internal.yml
+++ b/environments/ithc/service-core-compute-ithc-internal.yml
@@ -17,20 +17,4 @@ A:
     record:
     - 10.112.53.5
     ttl: 300
-  - name: neuvector00
-    record:
-    - 10.11.207.250
-    ttl: 300
-  - name: neuvector00-api
-    record:
-    - 10.11.207.250
-    ttl: 300
-  - name: neuvector01
-    record:
-    - 10.11.223.250
-    ttl: 300
-  - name: neuvector01-api
-    record:
-    - 10.11.223.250
-    ttl: 300
 cname: []


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-13348


### Change description ###

* Add A records for the internal private dns load balancers for CFT ITHC (traefik-cft-00/traefik-cft-01)
* CNAME existing A records that point to same address (prometheus/alertmanager)
* Change Neuvector ITHC domain from _core-compute-ithc.internal_ to _ithc.platform.hmcts.net_ with new CNAME entry


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
