### PR TITLE
CFT Prod - C Name internal DNS entries to new cluster LB record, change Neuvector domain

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -153,22 +153,6 @@ A:
     record:
     - 10.10.73.250
     ttl: 300
-  - name: prometheus-00
-    record:
-    - 10.90.79.250
-    ttl: 300
-  - name: prometheus-01
-    record:
-    - 10.90.95.250
-    ttl: 300
-  - name: alertmanager-00
-    record:
-    - 10.90.79.250
-    ttl: 300
-  - name: alertmanager-01
-    record:
-    - 10.90.95.250
-    ttl: 300
   - name: ccd-admin-web
     record:
     - 10.90.96.20
@@ -366,7 +350,14 @@ A:
     record:
     - 10.144.32.136
     ttl: 300        
-    
+  - name: traefik-cft-00
+    record:
+    - 10.90.79.250
+    ttl: 300
+  - name: traefik-cft-01
+    record:
+    - 10.90.95.250
+    ttl: 300
 cname:
   - name: c100-application
     ttl: 300
@@ -542,4 +533,28 @@ cname:
     ttl: 300
   - name: plum
     record: hmcts-prod.azurefd.net.
+    ttl: 300
+  - name: prometheus-00
+    record: traefik-cft-00.platform.hmcts.net.
+    ttl: 300
+  - name: prometheus-01
+    record: traefik-cft-01.platform.hmcts.net.
+    ttl: 300
+  - name: alertmanager-00
+    record: traefik-cft-00.platform.hmcts.net.
+    ttl: 300
+  - name: alertmanager-01
+    record: traefik-cft-01.platform.hmcts.net.
+    ttl: 300
+  - name: cft-neuvector00
+    record: traefik-cft-00.platform.hmcts.net.
+    ttl: 300
+  - name: cft-neuvector00-api
+    record: traefik-cft-00.platform.hmcts.net.
+    ttl: 300
+  - name: cft-neuvector01
+    record: traefik-cft-01.platform.hmcts.net.
+    ttl: 300
+  - name: cft-neuvector01-api
+    record: traefik-cft-01.platform.hmcts.net.
     ttl: 300


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-13348


### Change description ###

* Add A records for the internal private dns load balancers for CFT Prod (traefik-cft-00/traefik-cft-01)
* CNAME existing A records that point to same address (prometheus/alertmanager)
* Change Neuvector Prod domain from _core-compute-prod.internal_ to _.platform.hmcts.net_ with new CNAME entry


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
