### PR TITLE
Dtspo 13629 jbox dns platform zone

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -366,6 +366,14 @@ A:
     record:
     - 10.90.95.250
     ttl: 300
+  - name: jbox-nonprod
+    record:
+    - 10.48.0.53
+    ttl: 300
+  - name: jbox-prod
+    record:
+    - 10.48.2.5
+    ttl: 300
 cname:
   - name: c100-application
     ttl: 300
@@ -565,12 +573,4 @@ cname:
     ttl: 300
   - name: cft-neuvector01-api
     record: traefik-cft-01.platform.hmcts.net.
-    ttl: 300
-  - name: jbox-nonprod
-    record:
-    - 10.48.0.53
-    ttl: 300
-  - name: jbox-prod
-    record:
-    - 10.48.2.5
     ttl: 300

--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -32,6 +32,10 @@ vnet_links:
     registration_enabled: true
   - link_name: "hmi-sharedinfra-vnet-prod"
     vnet_id: "/subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/hmi-sharedinfra-prod-rg/providers/Microsoft.Network/virtualNetworks/hmi-sharedinfra-vnet-prod"
+  - link_name: "private-dns-resolver-uksouth-vnet-prod-int"
+    vnet_id: "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/private-dns-resolver-uksouth-prod-int/providers/Microsoft.Network/virtualNetworks/private-dns-resolver-uksouth-vnet-prod-int"
+  - link_name: "private-dns-resolver-uksouth-vnet-nonprodi"
+    vnet_id: "/subscriptions/fb084706-583f-4c9a-bdab-949aac66ba5c/resourceGroups/private-dns-resolver-uksouth-nonprodi/providers/Microsoft.Network/virtualNetworks/private-dns-resolver-uksouth-vnet-nonprodi"
 A:
   - name: aat-waf
     record:
@@ -561,4 +565,12 @@ cname:
     ttl: 300
   - name: cft-neuvector01-api
     record: traefik-cft-01.platform.hmcts.net.
+    ttl: 300
+  - name: jbox-nonprod
+    record:
+    - 10.48.0.53
+    ttl: 300
+  - name: jbox-prod
+    record:
+    - 10.48.2.5
     ttl: 300

--- a/environments/prod/prod-internal-hmcts-net.yml
+++ b/environments/prod/prod-internal-hmcts-net.yml
@@ -61,8 +61,4 @@ A:
     record:
     - 10.24.245.12
     ttl: 300
-  - name: jbox
-    record:
-    - 10.48.2.5
-    ttl: 300
 cname: []

--- a/environments/staging/staging-internal-hmcts-net.yml
+++ b/environments/staging/staging-internal-hmcts-net.yml
@@ -15,10 +15,6 @@ A:
     record:
     - 10.25.245.12
     ttl: 300
-  - name: jbox
-    record:
-    - 10.48.0.53
-    ttl: 300
 cname:
   - name: smallsystems
     record: ss01-sqlsrv-stg.privatelink.database.windows.net


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-13629


### Change description ###
Move the jbox A records to platform.hmcts.net and add DNS vNet links to enable resolver access


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
