### PR TITLE
sandbox.platform.hmcts.net: Remove stale cname records

### DIFF
--- a/environments/sandbox/sandbox-platform-hmcts-net.yml
+++ b/environments/sandbox/sandbox-platform-hmcts-net.yml
@@ -138,15 +138,6 @@ A:
     - 10.0.16.36
     ttl: 300
 cname:
-  - name: moneyclaim
-    record: sandbox-waf.sandbox.platform.hmcts.net.
-    ttl: 300
-  - name: moneyclaim-legal
-    record: sandbox-waf.sandbox.platform.hmcts.net.
-    ttl: 300
-  - name: fees-register
-    record: sandbox-waf.sandbox.platform.hmcts.net.
-    ttl: 300
   - name: idam-api
     record: idam-api-sbox.service.core-compute-sandbox.internal.
     ttl: 300
@@ -161,12 +152,6 @@ cname:
     ttl: 300
   - name: idam-web-public-sprod
     record: hmcts-sbox.azurefd.net.
-    ttl: 300
-  - name: payment
-    record: sandbox-waf.sandbox.platform.hmcts.net.
-    ttl: 300
-  - name: bar
-    record: sandbox-waf.sandbox.platform.hmcts.net.
     ttl: 300
   - name: idam-web-admin
     record: hmcts-sbox.azurefd.net.


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-13069


### Change description ###

This is a preparatory PR which will remove stale/un-needed CNAME records from sandbox.platform.hmcts.net after azure-platform-terraform ssl_enabled flag implementation has been run against cft sandbox. Jira above

Changes are:
 
- Remove cname records that point to a non-existing record
- Remove cname records where new A record replaces forwards to _hmcts-sbox.azurefd.net_ or _.core-compute-sandbox.internal_ 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
