### PR TITLE
DTSPO-13990 Updating dns for migrated test frontdoor

### DIFF
--- a/environments/sandbox/sandbox-platform-hmcts-net.yml
+++ b/environments/sandbox/sandbox-platform-hmcts-net.yml
@@ -195,7 +195,7 @@ cname:
     record: sdshmcts-sbox.azurefd.net.
     ttl: 300
   - name: toffee2
-    record: hmcts-test-sbox.azurefd.net.
+    record: hmcts-test-sbox-bjcpanf7ave7a6ep.z01.azurefd.net.
     ttl: 300
   - name: "labs-louisehuyton-walkthrough"
     ttl: 300


### PR DESCRIPTION
### JIRA link (if applicable) ###

[DTSPO-13990](https://tools.hmcts.net/jira/browse/DTSPO-13990)

### Change description ###

Migrated hmcts-test-sbox to hmcts-test-sbox-migrated need to updated the dns to point to the new frontdoor


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
