### PR TITLE
Add auto-registration VPN vnet link

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -21,6 +21,7 @@ vnet_links:
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/rg-mgmt/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-mgmt"
   - link_name: "vpn"
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/mgmt-vpn-2-mgmt/providers/Microsoft.Network/virtualNetworks/mgmt-vpn-2-vnet"
+    registration_enabled: true
   - link_name: "bastion-prod-vnet"
     vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/bastion-prod-rg/providers/Microsoft.Network/virtualNetworks/bastion-prod-vnet"
     registration_enabled: true


### PR DESCRIPTION
As part of [app-proxy work ](https://github.com/hmcts/azure-app-proxy/pull/2#event-9731065935) we want to auto-register VMs with private dns records - the link between the VNET (mgmt-vpn-2-vnet) and Private Zone already exists here.
[DTSPO-14061](https://tools.hmcts.net/jira/browse/DTSPO-14061)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
