### PR TITLE
Remove-duplicate-CNAMES

### DIFF
--- a/environments/dev/dev-platform-hmcts-net.yml
+++ b/environments/dev/dev-platform-hmcts-net.yml
@@ -71,9 +71,3 @@ cname:
   - name: signalr
     record: vh-infra-core-dev.service.signalr.net
     ttl: 300
-  - name: vh-video-web
-    record: sdshmcts-dev.azurefd.net
-    ttl: 300
-  - name: vh-admin-web
-    record: sdshmcts-dev.azurefd.net
-    ttl: 300

--- a/environments/prod/prod-internal-hmcts-net.yml
+++ b/environments/prod/prod-internal-hmcts-net.yml
@@ -2,6 +2,8 @@ name: "prod.internal.hmcts.net"
 vnet_links:
   - link_name: "private-dns-resolver-uksouth-vnet-prod-int"
     vnet_id: "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/private-dns-resolver-uksouth-prod-int/providers/Microsoft.Network/virtualNetworks/private-dns-resolver-uksouth-vnet-prod-int"
+  - link_name: "core-aad-domain-services-mgmt-vnet"
+    vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/core-aad-domain-services-mgmt-rg/providers/Microsoft.Network/virtualNetworks/core-aad-domain-services-mgmt-vnet"
   - link_name: "soc-prod-vnet"
     vnet_id: "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.Network/virtualNetworks/soc-prod-vnet"
 A:


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-14920


### Change description ###
Add core-aad-domain-services-mgmt-vnet vnet to Azure private DNS zone's virtual network link for prod.internal.hmcts.net.  Remove 
vh-video-web.dev.platform.hmcts.net & vh-admin-web.dev.platform.hmcts.net CNAMES which clash with the existing A records that point to 10.145.31.250

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
