### PR TITLE
Revert "Add pre-portal to sbox, demo, stg"

### DIFF
--- a/environments/demo/demo-platform-hmcts-net.yml
+++ b/environments/demo/demo-platform-hmcts-net.yml
@@ -474,6 +474,4 @@ cname:
   - name: pip-frontend
     record: sdshmcts-demo.azurefd.net
     ttl: 300
-  - name: pre-portal
-    record: sdshmcts-demo.azurefd.net
-    ttl: 300 
+    

--- a/environments/sandbox/sandbox-platform-hmcts-net.yml
+++ b/environments/sandbox/sandbox-platform-hmcts-net.yml
@@ -213,6 +213,3 @@ cname:
   - name: darts-portal
     record: sdshmcts-sbox.azurefd.net
     ttl: 300
-  - name: pre-portal
-    record: sdshmcts-sbox.azurefd.net
-    ttl: 300

--- a/environments/staging/staging-platform-hmcts-net.yml
+++ b/environments/staging/staging-platform-hmcts-net.yml
@@ -87,6 +87,3 @@ cname:
   - name: darts-portal
     record: sdshmcts-stg.azurefd.net
     ttl: 300
-  - name: pre-portal
-    record: sdshmcts-stg.azurefd.net
-    ttl: 300


### PR DESCRIPTION
Reverts hmcts/azure-private-dns#641

it looks like private DNS records are created as part of sds-azure-platform https://github.com/hmcts/sds-azure-platform/runs/16549743400