### PR TITLE
DTSPO-15318: Add private-dns for sds-jenkins to traefik

### DIFF
--- a/environments/prod/hmcts-net.yml
+++ b/environments/prod/hmcts-net.yml
@@ -1073,4 +1073,8 @@ A:
     record:
     - 10.147.15.250
     ttl: 300
+  - name: sds-build
+    record:
+    - 10.147.79.250
+    ttl: 300
 cname: []


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15318

Adds private-dns record for new sds-jenkins ptl URL before switching ingress

Flux change for ingress after this https://github.com/hmcts/sds-flux-config/pull/3709

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
