### PR TITLE
DTSPO-15318: Remove A record, add CNAME for sds jenkins to front door

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -80,10 +80,6 @@ A:
     ttl: 300
     record: 
       - "51.104.212.71"
-  - name: "sds-build"
-    ttl: 60
-    record:
-      - "13.87.65.228"
   - name: "static-sds-build"
     ttl: 60
     record:
@@ -584,5 +580,11 @@ cname:
     ttl: 300
     record: "sdshmcts-prod.azurefd.net"
   - name: "afdverify.sds-sandbox-build"
+    ttl: 3600
+    record: "afdverify.sdshmcts-prod.azurefd.net"
+  - name: "sds-build"
+    ttl: 300
+    record: "sdshmcts-prod.azurefd.net"
+  - name: "afdverify.sds-build"
     ttl: 3600
     record: "afdverify.sdshmcts-prod.azurefd.net"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15318

After https://github.com/hmcts/sds-flux-config/pull/3709 this change adds a CNAME for old url to front door, which after https://github.com/hmcts/sds-azure-platform/pull/599 will contain a redirect to new url

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
