### PR TITLE
Add core-infra-vnet-mgmt link for Purview

### DIFF
--- a/environments/privatelink/purview-private-link.yml
+++ b/environments/privatelink/purview-private-link.yml
@@ -1,5 +1,6 @@
 name: "privatelink.purview.azure.com"
-vnet_links: []
-
+vnet_links:
+- link_name: "core-infra-vnet-mgmt"
+    vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/rg-mgmt/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-mgmt"
 A: []
 cname: []

--- a/environments/privatelink/purview-private-link.yml
+++ b/environments/privatelink/purview-private-link.yml
@@ -2,5 +2,7 @@ name: "privatelink.purview.azure.com"
 vnet_links:
   - link_name: "core-infra-vnet-mgmt"
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/rg-mgmt/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-mgmt"
+  - link_name: "vpn"
+    vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/mgmt-vpn-2-mgmt/providers/Microsoft.Network/virtualNetworks/mgmt-vpn-2-vnet"
 A: []
 cname: []

--- a/environments/privatelink/purview-private-link.yml
+++ b/environments/privatelink/purview-private-link.yml
@@ -1,6 +1,6 @@
 name: "privatelink.purview.azure.com"
 vnet_links:
-- link_name: "core-infra-vnet-mgmt"
+  - link_name: "core-infra-vnet-mgmt"
     vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/rg-mgmt/providers/Microsoft.Network/virtualNetworks/core-infra-vnet-mgmt"
 A: []
 cname: []


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DC-47


### Change description ###
The Data Catalogue team needs to set up a vnet that uses private endpoints to restrict access to a Purview account. Currently it seems that vpn access to Purview is missing via private link, which is added in this PR

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
