### PR TITLE
DTSPO-15525: Add DNS for central neuvector

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -347,6 +347,10 @@ A:
     record:
     - 10.10.73.250
     ttl: 300
+  - name: cft-neuvector
+    record:
+    - 10.10.73.250
+    ttl: 300
 
 cname:
   - name: c100-application


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15525

Adds private-dns for access to new central neuvector instance

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
