### PR TITLE
fix: updated DNS to point to libra in IH rather than VF

### DIFF
--- a/environments/prod/lncs-hmcs.yml
+++ b/environments/prod/lncs-hmcs.yml
@@ -7,7 +7,7 @@ vnet_links:
 A:
   - name: lncs-onpremisegobgateway-uat
     record:
-      - 10.72.1.229
+      - 10.25.15.79
     ttl: 300
   - name: lncs-onpremisegobgateway
     record:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16475


### Change description ###
Updated DNS used by LibraGoB Integration services to point to IH rather than VF.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
