### PR TITLE
Remove cname blocking pipeline

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -622,6 +622,3 @@ cname:
   - name: "www.paymentoutcome-web"
     ttl: 3600
     record: "hmcts-prod-hdgpbqdkafhmcse9.z01.azurefd.net"
-  - name: "pre-portal"
-    ttl: 300
-    record: "sdshmcts-prod-egd0dscwgwh0bpdq.z01.azurefd.net"


### PR DESCRIPTION
### Change description ###
pre-portal cname is causing an issue in sds-azure-platform as an A record cannot be created when an identical CNAME record exists
The CNAME was added due to failing checks in daily checks
Will keep an eye on daily checks for future in case a more permanent fix is needed

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
