### PR TITLE
DTSPO-16138 - Link dynatrace prod vnet to aat

### DIFF
--- a/environments/staging/aat-platform-hmcts-net.yml
+++ b/environments/staging/aat-platform-hmcts-net.yml
@@ -20,6 +20,8 @@ vnet_links:
     vnet_id: "/subscriptions/b44eb479-9ae2-42e7-9c63-f3c599719b6f/resourceGroups/bastion-nonprod-rg/providers/Microsoft.Network/virtualNetworks/bastion-nonprod-vnet"
   - link_name: "hmi-sharedinfra-vnet-stg"
     vnet_id: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/hmi-sharedinfra-stg-rg/providers/Microsoft.Network/virtualNetworks/hmi-sharedinfra-vnet-stg"
+  - link_name: "dynatrace-activegate-vnet-prod"
+    vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/dynatrace-activegate-prod/providers/Microsoft.Network/virtualNetworks/dynatrace-activegate-vnet-prod"
 A:
   - name: test-dns-update
     ttl: 300


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16138

### Change description ###
Link dynatrace prod vnet to aat zone to activegates can resolve dns

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
