### PR TITLE
Add-Dynatrace-active-gateway-vNet-link

### DIFF
--- a/environments/prod/prod-internal-hmcts-net.yml
+++ b/environments/prod/prod-internal-hmcts-net.yml
@@ -8,6 +8,8 @@ vnet_links:
     vnet_id: "/subscriptions/8ae5b3b6-0b12-4888-b894-4cec33c92292/resourceGroups/soc-core-infra-prod-rg/providers/Microsoft.Network/virtualNetworks/soc-prod-vnet"
   - link_name: "cft-prod-vnet"
     vnet_id: "/subscriptions/8cbc6f36-7c56-4963-9d36-739db5d00b27/resourceGroups/cft-prod-network-rg/providers/Microsoft.Network/virtualNetworks/cft-prod-vnet"
+  - link_name: "dynatrace-activegate-vnet-prod"
+    vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/dynatrace-activegate-prod/providers/Microsoft.Network/virtualNetworks/dynatrace-activegate-vnet-prod"
 A:
   - name: familyman
     record:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18179


### Change description ###
The Dynatrace active gateway nodes need to be able to DNS resolve familyman.prod.internal.hmcts.net.  This will add the vNET link on prod.internal.hmcts.net

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
