### PR TITLE
Remove-vNET-link-sbox-dns-private-resolver

### DIFF
--- a/environments/sandbox/sandbox-internal-hmcts-net.yml
+++ b/environments/sandbox/sandbox-internal-hmcts-net.yml
@@ -3,3 +3,4 @@ vnet_links: []
 
 A: []
 cname: []
+


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18179


### Change description ###
Can't run pipeline as SBOX Private DNS resolver has been removed.  Need to take vNET link out.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
