### PR TITLE
DTSPO-18493 - Remove link to missing vnet

### DIFF
--- a/environments/sandbox/sandbox-platform-hmcts-net.yml
+++ b/environments/sandbox/sandbox-platform-hmcts-net.yml
@@ -12,8 +12,6 @@ vnet_links:
     vnet_id: "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/private-dns-resolver-uksouth-prod-int/providers/Microsoft.Network/virtualNetworks/private-dns-resolver-uksouth-vnet-prod-int"
   - link_name: "bastion-sbox-vnet"
     vnet_id: "/subscriptions/b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac/resourceGroups/bastion-sbox-rg/providers/Microsoft.Network/virtualNetworks/bastion-sbox-vnet"
-  - link_name: "hmi-sharedinfra-vnet-sbox"
-    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/hmi-sharedinfra-sbox-rg/providers/Microsoft.Network/virtualNetworks/hmi-sharedinfra-vnet-sbox"
   - link_name: "cft-ptl-vnet"
     vnet_id: "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/cft-ptl-network-rg/providers/Microsoft.Network/virtualNetworks/cft-ptl-vnet"
   - link_name: "dynatrace-activegate-vnet-nonprod"

--- a/environments/sandbox/sbox-platform-hmcts-net.yml
+++ b/environments/sandbox/sbox-platform-hmcts-net.yml
@@ -12,8 +12,6 @@ vnet_links:
     vnet_id: "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/private-dns-resolver-uksouth-prod-int/providers/Microsoft.Network/virtualNetworks/private-dns-resolver-uksouth-vnet-prod-int"
   - link_name: "bastion-sbox-vnet"
     vnet_id: "/subscriptions/b3394340-6c9f-44ca-aa3e-9ff38bd1f9ac/resourceGroups/bastion-sbox-rg/providers/Microsoft.Network/virtualNetworks/bastion-sbox-vnet"
-  - link_name: "hmi-sharedinfra-vnet-sbox"
-    vnet_id: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/hmi-sharedinfra-sbox-rg/providers/Microsoft.Network/virtualNetworks/hmi-sharedinfra-vnet-sbox"
 A: []
 cname: 
   - name: vh-video-web


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18493

### Change description ###
Remove link to vnet that no longer exists in the same location
There seems to have been an error in creating the vnet that meant the resource group was named incorrectly
There is no link atm so this won't affect anything other than fixing the pipeline

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
