### PR TITLE
use apim appgw ip aat

### DIFF
--- a/environments/staging/aat-platform-hmcts-net.yml
+++ b/environments/staging/aat-platform-hmcts-net.yml
@@ -59,7 +59,7 @@ A:
     ttl: 300
   - name: cft-mtls-api-mgmt-appgw
     record:
-    - 10.10.161.132
+    - 10.11.8.215
     ttl: 300
   - name: traefik-cft-00
     record:


### PR DESCRIPTION
### Change description

Update dns for cft-mtls-api-mgmt-appgw to use appgw private ip, not apim private ip

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
