### PR TITLE
DTSPO-19124: Allow dmz vnets to read platform.hmcts.net

### DIFF
--- a/components/sandbox/provider.tf
+++ b/components/sandbox/provider.tf
@@ -1,5 +1,6 @@
 provider "azurerm" {
   features {}
+  skip_provider_registration = true
 }
 
 terraform {

--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -49,6 +49,10 @@ vnet_links:
   - link_name: "dynatrace-activegate-vnet-prod"
     vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/dynatrace-activegate-prod/providers/Microsoft.Network/virtualNetworks/dynatrace-activegate-vnet-prod"
     registration_enabled: true
+  - link_name: "dmz-nonprod"
+    vnet_id: "/subscriptions/fb084706-583f-4c9a-bdab-949aac66ba5c/resourceGroups/hmcts-dmz-nonprodi/providers/Microsoft.Network/virtualNetworks/hmcts-dmz-nonprodi"
+  - link_name: "dmz-prod"
+    vnet_id: "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/hmcts-dmz-prod-int/providers/Microsoft.Network/virtualNetworks/hmcts-dmz-prod-int"
 A:
   - name: aat-waf
     record:


### PR DESCRIPTION
DTSPO-19124

This is needed for DNS resolution from f5 loadbalancers (f5-nonprodi and f5-prod-int) for remote logging to XSIAM

