### PR TITLE
Updated dynatrace DNS record

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -662,7 +662,7 @@ cname:
     record: dynatrace-activegate-private-prod-vmss000001.platform.hmcts.net
     ttl: 300
   - name: dynatrace-activegate-nonprod
-    record: dynatrace-activegate-nonprod-vmss000001.platform.hmcts.net
+    record: dynatrace-activegate-nonprod-vmss000002.platform.hmcts.net
     ttl: 300
   - name: dynatrace-activegate-private-nonprod
     record: dynatrace-activegate-private-nonprod-vmss000001.platform.hmcts.net


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18828

### Change description

dynatrace-activegate-nonprod-vmss000001  does not exist hence nonprod VMs were failing to download the agents.



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
