### PR TITLE
DTSPO-22707-Add-video-hearings-vNet-Link

### DIFF
--- a/environments/prod/hearings-reform-hmcts-net.yml
+++ b/environments/prod/hearings-reform-hmcts-net.yml
@@ -8,6 +8,8 @@ vnet_links:
     vnet_id: "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/private-dns-resolver-uksouth-prod-int/providers/Microsoft.Network/virtualNetworks/private-dns-resolver-uksouth-vnet-prod-int"
   - link_name: "cftptl"
     vnet_id: "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/cft-ptl-network-rg/providers/Microsoft.Network/virtualNetworks/cft-ptl-vnet"
+  - link_name: "core-aad-domain-services-mgmt-vnet"
+    vnet_id: "/subscriptions/2b1afc19-5ca9-4796-a56f-574a58670244/resourceGroups/core-aad-domain-services-mgmt-rg/providers/Microsoft.Network/virtualNetworks/core-aad-domain-services-mgmt-vnet"
 
 A: []
 cname:


### PR DESCRIPTION
### Jira link

See [DTSPO-22707](https://tools.hmcts.net/jira/browse/DTSPO-22707)

### Change description

Need users on F5 VPN to be able to resolve video.hearings.reform.hmcts.net via the internal DNS servers

### Testing done

Manually added vNet link via Azure portal and problem resolved.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
