### PR TITLE
Add Private link for PRE blobs in dev

### DIFF
--- a/environments/privatelink/blob-private-link.yml
+++ b/environments/privatelink/blob-private-link.yml
@@ -22,5 +22,7 @@ vnet_links:
     vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/pre-test/providers/Microsoft.Network/virtualNetworks/pre-vnet01-test"
   - link_name: "pre-demo-vnet"
     vnet_id: "/subscriptions/c68a4bed-4c3d-4956-af51-4ae164c1957c/resourceGroups/pre-demo/providers/Microsoft.Network/virtualNetworks/pre-vnet01-demo"
+  - link_name: "pre-dev-dnet"
+    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/pre-dev/providers/Microsoft.Network/virtualNetworks/pre-vnet-dev"
 A: []
 cname: []


### PR DESCRIPTION
Getting error trying to run the PRE shared infa pipeline against dev env:

```
10:35:25  [31m│[0m [0m[1m[31mError: [0m[0m[1mretrieving static website properties for Storage Account (Subscription: "****"
10:35:25  [31m│[0m [0mResource Group Name: "pre-dev"
10:35:25  [31m│[0m [0mStorage Account Name: "prefinalsadev"): executing request: Get "https://prefinalsadev.blob.core.windows.net/?comp=properties&restype=service": dial tcp: lookup prefinalsadev.blob.core.windows.net on 127.0.0.53:53: no such host[0m
```

This PR should allow jenkins to resolve prefinalsadev.blob.core.windows.net to it's private ip