### PR TITLE
Revert "Add Private link for PRE blobs in dev"

### DIFF
--- a/environments/privatelink/blob-private-link.yml
+++ b/environments/privatelink/blob-private-link.yml
@@ -22,7 +22,5 @@ vnet_links:
     vnet_id: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/pre-test/providers/Microsoft.Network/virtualNetworks/pre-vnet01-test"
   - link_name: "pre-demo-vnet"
     vnet_id: "/subscriptions/c68a4bed-4c3d-4956-af51-4ae164c1957c/resourceGroups/pre-demo/providers/Microsoft.Network/virtualNetworks/pre-vnet01-demo"
-  - link_name: "pre-dev-dnet"
-    vnet_id: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/pre-dev/providers/Microsoft.Network/virtualNetworks/pre-vnet-dev"
 A: []
 cname: []


### PR DESCRIPTION
Reverts hmcts/azure-private-dns#871
`{"error":{"code":"BadRequest","message":"A virtual network cannot be linked to multiple zones with overlapping namespaces. You tried to link virtual network with 'privatelink.blob.core.windows.net' and 'privatelink.blob.core.windows.net' zones."},"status":"Failed"}`