### PR TITLE
DTSPO-23915 adding private dns for ithc pubsub

### DIFF
--- a/environments/ithc/ithc-platform-hmcts-net.yml
+++ b/environments/ithc/ithc-platform-hmcts-net.yml
@@ -89,6 +89,10 @@ A:
     record:
     - 10.143.44.4
     ttl: 300 
+  - name: em-icp-webpubsub
+    record:
+    - 10.11.226.8
+    ttl: 300
 cname:
   - name: c100-application
     ttl: 300


### PR DESCRIPTION
### Jira link

[DTSPO-23915](https://tools.hmcts.net/jira/browse/DTSPO-23915)

### Change description

adding this entry to try testing the ithc pubsub health probe on a private dns

