### PR TITLE
Remove decommed servers from prod-internal-hmcts-net.yml

### DIFF
--- a/environments/prod/prod-internal-hmcts-net.yml
+++ b/environments/prod/prod-internal-hmcts-net.yml
@@ -15,45 +15,9 @@ A:
     record:
       - 10.23.15.11
     ttl: 300
-  - name: data-analytics
-    record:
-      - 10.23.4.132
-    ttl: 300
   - name: xhibitthin
     record:
       - 10.23.1.253
-    ttl: 300
-  - name: pih4171sec001
-    record:
-      - 10.23.3.164
-    ttl: 300
-  - name: pih4171sec002
-    record:
-      - 10.23.3.165
-    ttl: 300
-  - name: pih4171sec003
-    record:
-      - 10.23.3.166
-    ttl: 300
-  - name: pih4171sec004
-    record:
-      - 10.23.3.167
-    ttl: 300
-  - name: pih4172sec001
-    record:
-      - 10.25.3.164
-    ttl: 300
-  - name: pih4172sec002
-    record:
-      - 10.25.3.165
-    ttl: 300
-  - name: pih4172sec003
-    record:
-      - 10.25.3.166
-    ttl: 300
-  - name: pih4172sec004
-    record:
-      - 10.25.3.167
     ttl: 300
   - name: pihw4172rdp001
     record:
@@ -74,10 +38,6 @@ A:
   - name: pihw4172dfs001
     record:
       - 10.25.3.150
-    ttl: 300
-  - name: pihw4171dfs001
-    record:
-      - 10.23.3.150
     ttl: 300
   - name: martha
     record:


### PR DESCRIPTION
This change is to remove the following decomissioned servers

data-analytics
pihw4171dfs001
pihl4171sec001-4
pihl4172sec001-4

### Jira link

<!-- 
N/A

<!--
Provide a description of what change you are proposing.
Removal of DNS entries for decommissioned servers
-->

### Testing done

<!-- Comment:
N/A as servers have already been decommed
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x ] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)
- [x ] Does this PR introduce a breaking change
