### PR TITLE
DTSPO-24907 - Remove vpn from private link

### DIFF
--- a/environments/privatelink/machine-learning-private-link.yml
+++ b/environments/privatelink/machine-learning-private-link.yml
@@ -1,11 +1,9 @@
 name: "privatelink.api.azureml.ms"
 vnet_links:
-  - link_name: "vpn"
-    vnet_id: "/subscriptions/ed302caf-ec27-4c64-a05e-85731c3ce90e/resourceGroups/mgmt-vpn-2-mgmt/providers/Microsoft.Network/virtualNetworks/mgmt-vpn-2-vnet"
   - link_name: "private-dns-resolver-uksouth-vnet-prod-int"
     vnet_id: "/subscriptions/0978315c-75fe-4ada-9d11-1eb5e0e0b214/resourceGroups/private-dns-resolver-uksouth-prod-int/providers/Microsoft.Network/virtualNetworks/private-dns-resolver-uksouth-vnet-prod-int"
   - link_name: "ingest00-vnet-sbox"
     vnet_id: "/subscriptions/df72bb30-d6fb-47bd-82ee-5eb87473ddb3/resourceGroups/ingest00-network-sbox/providers/Microsoft.Network/virtualNetworks/ingest00-vnet-sbox"
-    
+
 A: []
 cname: []


### PR DESCRIPTION
### Jira link

See [DTSPO-24907](https://tools.hmcts.net/jira/browse/DTSPO-24907)

### Change description

Another private zone has this link already and there can't be overlaps

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

