### PR TITLE
fix em-icp routing in private dns to AFD

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -522,6 +522,9 @@ cname:
   - name: register-org
     record: hmcts-prod-hdgpbqdkafhmcse9.z01.azurefd.net.
     ttl: 300
+  - name: em-icp
+    record: hmcts-prod-hdgpbqdkafhmcse9.z01.azurefd.net.
+    ttl: 300
   - name: manage-case
     record: hmcts-prod-hdgpbqdkafhmcse9.z01.azurefd.net.
     ttl: 300


### PR DESCRIPTION
### Change description
Fix error from aks
`getaddrinfo ENOTFOUND em-icp.platform.hmcts.net`
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->
