### PR TITLE
Revert "add em-icp-webpubsub application gateway"

### DIFF
--- a/environments/prod/platform-hmcts-net.yml
+++ b/environments/prod/platform-hmcts-net.yml
@@ -58,10 +58,6 @@ A:
     record:
     - 51.140.157.202
     ttl: 300
-  - name: em-icp-webpubsub
-    record:
-    - 85.210.29.141
-    ttl: 300
   - name: prod-waf
     record:
     - 51.140.154.148


### PR DESCRIPTION
Reverts hmcts/azure-private-dns#899
- not needed, lower envs dont have this