### PR TITLE
Updating jenkins-cluster cname to use traefik A record for cluster-00

### DIFF
--- a/environments/staging/aat-platform-hmcts-net.yml
+++ b/environments/staging/aat-platform-hmcts-net.yml
@@ -381,7 +381,7 @@ cname:
     record: traefik-cft-00.aat.platform.hmcts.net
     ttl: 300
   - name: jenkins-cluster
-    record: traefik-cft-01.aat.platform.hmcts.net
+    record: traefik-cft-00.aat.platform.hmcts.net
     ttl: 300
   - name: wa-workflow-camunda-staging
     record: jenkins-cluster.aat.platform.hmcts.net.


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-26020

### Change description
Updating jenkins-cluster cname to use traefik A record for cluster-00