### PR TITLE
labs-hurricanepilot-nodejs private dns config

### DIFF
--- a/environments/sandbox/sandbox-platform-hmcts-net.yml
+++ b/environments/sandbox/sandbox-platform-hmcts-net.yml
@@ -232,3 +232,6 @@ cname:
   - name: "labs-lukaszk-hmcts-nodejs"
     ttl: 300
     record: "hmcts-sbox-gufqadefbjgbhkhv.z01.azurefd.net"
+  - name: "labs-hurricanepilot-nodejs"
+    ttl: 300
+    record: "hmcts-sbox-gufqadefbjgbhkhv.z01.azurefd.net"


### PR DESCRIPTION
### Change description

Adding private dns config for `labs-hurricanepilot-nodejs` as per instructions in the nodejs golden path
