### PR TITLE
Remove pip-frontend A record from test Private DNS Zone and replace with a CNAME, same as rest of non-prod

### DIFF
--- a/components/test/test-platform.tf
+++ b/components/test/test-platform.tf
@@ -13,8 +13,3 @@ module "test-platform" {
   builtFrom           = var.builtFrom
   product             = var.product
 }
-
-import {
-  to = module.test-platform.azurerm_private_dns_a_record.this["pip-frontend"]
-  id = "/subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/test.platform.hmcts.net/A/pip-frontend"
-}

--- a/environments/test/test-platform-hmcts-net.yml
+++ b/environments/test/test-platform-hmcts-net.yml
@@ -59,10 +59,6 @@ A:
     record:
     - 10.141.48.4
     ttl: 300
-  - name: pip-frontend
-    record:
-    - 10.141.32.134
-    ttl: 300
 cname:
   - name: hmi-apim
     record: hmcts-perftest-c5g8ard0d4c5cdd9.z01.azurefd.net.
@@ -76,12 +72,9 @@ cname:
   - name: toffee
     record: sdshmcts-test-a2d9enhbenftckhu.z01.azurefd.net.
     ttl: 300
-  # Comment out for now because it conflicts with an incorrect A record that is not within the state
-  # Once A record is imported it will then be removed while the correct CNAME below will be uncommeted and applied
-  # Same record as in ITHC, Demo, Staging
-  # - name: pip-frontend
-  #   record: sdshmcts-test-a2d9enhbenftckhu.z01.azurefd.net
-  #   ttl: 300
+  - name: pip-frontend
+    record: sdshmcts-test-a2d9enhbenftckhu.z01.azurefd.net
+    ttl: 300
   - name: sign-in.pip-frontend
     record: sdshmcts-test-a2d9enhbenftckhu.z01.azurefd.net
     ttl: 300


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-28306

### Change description
Continuing from this PR: https://github.com/hmcts/azure-private-dns/pull/948
Remove pip-frontend A record resource after getting it imported into the state.
Replace with CNAME which should fix Jenkins Agent connectivity issue.

### Testing done
TF Plan

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
