### PR TITLE
DTSPO-27918 Update jenkins-cluster IP to aat-01

### DIFF
--- a/environments/staging/service-core-compute-aat-internal.yml
+++ b/environments/staging/service-core-compute-aat-internal.yml
@@ -47,7 +47,7 @@ A:
     ttl: 300
   - name: jenkins-cluster
     record:
-    - 10.10.143.250
+    - 10.10.159.250
     ttl: 300
   - name: ccd-data-0
     record:


### PR DESCRIPTION
### Jira link

[DTSPO-27918](https://tools.hmcts.net/jira/browse/DTSPO-27918)

### Change description

jenkins is moving to aat-01 updating dns to match

https://github.com/hmcts/cnp-flux-config/pull/41802