### PR TITLE
Corrected hmcts-access staging deployment URL

### DIFF
--- a/environments/staging/aat-platform-hmcts-net.yml
+++ b/environments/staging/aat-platform-hmcts-net.yml
@@ -178,7 +178,7 @@ cname:
   - name: idam-user-dashboard-staging
     record: hmcts-aat-dbdveha6dnc7ejdt.z01.azurefd.net.
     ttl: 300
-  - name: hmcts-access-staging
+  - name: idam-hmcts-access-staging
     record: hmcts-aat-dbdveha6dnc7ejdt.z01.azurefd.net.
     ttl: 300
   - name: idam-user-profile-bridge


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/SIDM-10375

### Change description
Hmcts-access functional tests should run via Front Door (see https://github.com/hmcts/cnp-jenkins-library#running-tests-through-azure-front-door).
This has not been the case until now as the DNS record for the staging deployment has been incorrect.
The DNS record should match the chart name which is `idam-hmcts-access`.

### Testing done
N/A

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
