### PR TITLE
DTSPO-31599: update sandbox-build approxy dns's for cft ptlsbox jenkins

### DIFF
--- a/environments/prod/hmcts-net.yml
+++ b/environments/prod/hmcts-net.yml
@@ -1109,7 +1109,7 @@ A:
     ttl: 300
   - name: sandbox-build
     record:
-    - 10.70.25.250
+    - 10.70.24.149
     ttl: 300
   - name: tools
     ttl: 600
@@ -1129,7 +1129,7 @@ A:
     ttl: 300
   - name: cft-sandbox-sonarqube-webhook
     record:
-      - 10.70.25.250
+      - 10.70.24.149
     ttl: 300
   - name: sds-sonarqube-webhook
     record:


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31599

### Change description

- ptlsbox cluster ip was changed on rebuild
- internal sandbox.platform.hmcts.net & static-sandbox-build dns updated, somehow missed these two for approxy which needs updating too

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
